### PR TITLE
add boundlessgeo maven repo for schema-0.12

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -3,8 +3,11 @@ apply plugin: "com.android.application"
 repositories {
   maven { url 'https://maven.fabric.io/public' }
   maven {
-        url "https://repo.eclipse.org/content/repositories/paho-releases/"
-    }
+      url 'https://repo.eclipse.org/content/repositories/paho-releases/'
+  }
+  maven {
+      url 'https://repo.boundlessgeo.com/release/'
+  }
 }
 import com.android.build.OutputFile
 


### PR DESCRIPTION
It's weird to me, but it seems UNCollector must have this maven repo defined now that android gradle is pulling the schema from boundlessgeo maven. My guess is maybe there's some exporting or linking we're supposed to be doing somewhere... though all projects required eclipse paho as well...